### PR TITLE
Fixes a couple things in the display of test output

### DIFF
--- a/src/Test/Runner/Html.elm
+++ b/src/Test/Runner/Html.elm
@@ -153,7 +153,7 @@ view model =
 
         failures : List ( List String, List Expectation )
         failures =
-            List.filter (snd >> List.all ((/=) Expect.pass)) model.completed
+            List.filter (snd >> List.any ((/=) Expect.pass)) model.completed
     in
         div [ style [ ( "width", "960px" ), ( "margin", "auto 40px" ), ( "font-family", "verdana, sans-serif" ) ] ]
             [ summary

--- a/src/Test/Runner/Html.elm
+++ b/src/Test/Runner/Html.elm
@@ -126,7 +126,7 @@ view model =
                                         [ th [ style thStyle ]
                                             [ text "Passed" ]
                                         , td []
-                                            [ text (toString completedCount) ]
+                                            [ text (toString (completedCount - List.length failures)) ]
                                         ]
                                     , tr []
                                         [ th [ style thStyle ]


### PR DESCRIPTION
A couple things I noticed in trying out this test runner:

1) The "passed" count is also including failed examples
2) The failures are only including examples that _all_ fail. I think an example should fail if _any_ assertion fails.
